### PR TITLE
fix: Remain insert when no args

### DIFF
--- a/langs/ts-docstr-c++.el
+++ b/langs/ts-docstr-c++.el
@@ -90,7 +90,8 @@
 (defun ts-docstr-c++--parse-return (nodes-pl)
   "Return t if function does have return value."
   (let* ((node-pl (nth 0 nodes-pl))
-         (parent (tsc-get-parent node-pl))
+         (parent-func-dec (tsc-get-parent node-pl))
+         (parent-func-def (tsc-get-parent parent-func-dec))
          (return t))
     ;; OKAY: We don't traverse like `JavaScript' does, since C/C++ needs to declare
     ;; return type in the function declaration.
@@ -99,7 +100,7 @@
        (when (ts-docstr-leaf-p node)
          (when (string= (tsc-node-text node) "void")
            (setq return nil))))
-     parent)
+     parent-func-def)
     return))
 
 ;;;###autoload
@@ -159,9 +160,9 @@
   (ts-docstr-with-insert-indent
     (cl-case (tsc-node-type node)
       (function_declarator  ; For function
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length variables)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length variables)))
          (ts-docstr-with-style-case
            ((or doxygen qt)
             (ts-docstr-insert c-start "\n")

--- a/langs/ts-docstr-csharp.el
+++ b/langs/ts-docstr-csharp.el
@@ -163,9 +163,9 @@
   (ts-docstr-with-insert-indent
     (cl-case (tsc-node-type node)
       ((or method_declaration delegate_declaration)
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length types)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length types)))
          (ts-docstr-with-style-case
            (doxygen
             (ts-docstr-insert c-start "\n")
@@ -184,7 +184,9 @@
             (insert c-start "\n")
             (insert c-prefix (ts-docstr-format 'summary) "\n")
             (setq restore-point (1- (point)))
-            (insert c-end "\n")
+            (insert c-end)
+            (unless (zerop len)
+              (insert "\n"))
             (dotimes (index len)
               (insert c-prefix (ts-docstr-format 'param :variable (nth index variables))
                       (if (= index (1- len)) "" "\n")))

--- a/langs/ts-docstr-java.el
+++ b/langs/ts-docstr-java.el
@@ -145,9 +145,9 @@
   (ts-docstr-with-insert-indent
     (cl-case (tsc-node-type node)
       (method_declaration  ; For function
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length variables)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length variables)))
          (ts-docstr-with-style-case
            (javadoc
             (ts-docstr-insert c-start "\n")

--- a/langs/ts-docstr-php.el
+++ b/langs/ts-docstr-php.el
@@ -145,9 +145,9 @@
   (ts-docstr-with-insert-indent
     (cl-case (tsc-node-type node)
       (function_definition
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length variables)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length variables)))
          (ts-docstr-with-style-case
            (phpdoc
             (ts-docstr-insert c-start "\n")

--- a/langs/ts-docstr-python.el
+++ b/langs/ts-docstr-python.el
@@ -196,9 +196,9 @@
   (ts-docstr-with-insert-indent-hold
     (cl-case (tsc-node-type node)
       (function_definition  ; For function
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length variables)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length variables)))
          ;; XXX: Start insert the differences!
          (ts-docstr-with-style-case
            (pep-257

--- a/langs/ts-docstr-ruby.el
+++ b/langs/ts-docstr-ruby.el
@@ -144,15 +144,17 @@
   (ts-docstr-with-insert-indent
     (cl-case (tsc-node-type node)
       (method  ; For function
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length variables)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length variables)))
          (ts-docstr-with-style-case
            (rdoc
             (ts-docstr-insert c-start "\n")
             (ts-docstr-insert c-prefix (ts-docstr-format 'summary) "\n")
             (setq restore-point (1- (point)))
-            (ts-docstr-insert c-prefix "\n")
+            (ts-docstr-insert c-prefix)
+            (unless (zerop len)
+              (insert "\n"))
             (dotimes (index len)
               (ts-docstr-insert c-prefix
                                 (ts-docstr-format 'param

--- a/langs/ts-docstr-rust.el
+++ b/langs/ts-docstr-rust.el
@@ -161,17 +161,20 @@
   (ts-docstr-with-insert-indent
     (cl-case (tsc-node-type node)
       ((or function_item function_signature_item)
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length variables)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length variables)))
          (ts-docstr-with-style-case
            (rfc-430
             (ts-docstr-insert c-start "\n")
-            (ts-docstr-insert c-prefix (ts-docstr-format 'summary) "\n")
+            (ts-docstr-insert c-prefix (ts-docstr-format 'summary))
+            (unless (zerop len)
+              (insert "\n"))
             (setq restore-point (1- (point)))
-            (ts-docstr-insert c-prefix "\n")
-            (ts-docstr-insert c-prefix (plist-get config :header-arg) "\n")
-            (ts-docstr-insert c-prefix "\n")
+            (unless (zerop len)
+              (ts-docstr-insert c-prefix "\n")
+              (ts-docstr-insert c-prefix (plist-get config :header-arg) "\n")
+              (ts-docstr-insert c-prefix "\n"))
             (dotimes (index len)
               (ts-docstr-insert c-prefix
                                 (ts-docstr-format 'param

--- a/langs/ts-docstr-scala.el
+++ b/langs/ts-docstr-scala.el
@@ -152,9 +152,9 @@
   (ts-docstr-with-insert-indent
     (cl-case (tsc-node-type node)
       (function_definition  ; For function
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length variables)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length variables)))
          (ts-docstr-with-style-case
            (scaladoc
             (ts-docstr-insert c-start "\n")

--- a/langs/ts-docstr-swift.el
+++ b/langs/ts-docstr-swift.el
@@ -165,9 +165,9 @@
   (ts-docstr-with-insert-indent
     (cl-case (tsc-node-type node)
       (function_declaration
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length variables)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length variables)))
          (ts-docstr-with-style-case
            (swift-doc
             (ts-docstr-insert c-start "\n")

--- a/langs/ts-docstr-typescript.el
+++ b/langs/ts-docstr-typescript.el
@@ -169,9 +169,9 @@
   (ts-docstr-with-insert-indent
     (cl-case (tsc-node-type node)
       ((or function_declaration method_definition)  ; For function
-       (when-let* ((types (plist-get data :type))
-                   (variables (plist-get data :variable))
-                   (len (length variables)))
+       (let* ((types (plist-get data :type))
+              (variables (plist-get data :variable))
+              (len (length variables)))
          (ts-docstr-with-style-case
            ((or typedoc tsdoc jsdoc google)
             (ts-docstr-insert c-start "\n")

--- a/ts-docstr-key.el
+++ b/ts-docstr-key.el
@@ -336,7 +336,7 @@ document string."
     (when (and (ts-docstr--line-is "///")
                (ts-docstr--looking-back "///" 3)
                (ts-docstr-activatable-p))
-      (backward-delete-char 3)
+      (delete-char -3)
       (ts-docstr-at-point))))
 
 (defun ts-docstr-key-go-/ (&rest _)
@@ -345,7 +345,7 @@ document string."
     (when (and (ts-docstr--line-is "//")
                (ts-docstr--looking-back "//" 2)
                (ts-docstr-activatable-p))
-      (backward-delete-char 2)
+      (delete-char -2)
       (ts-docstr-at-point))))
 
 (defun ts-docstr-key-python-dq (&rest _)
@@ -363,9 +363,9 @@ document string."
       (let ((old-tree tree-sitter-tree))
         (if (ts-docstr--looking-back "\"\"\"" 5)
             (progn
-              (backward-delete-char 5)
+              (delete-char -5)
               (delete-char 1))
-          (backward-delete-char 3)
+          (delete-char -3)
           (delete-char 3))
         (setq tree-sitter-tree old-tree)  ; keep the old parsed tree
         (ts-docstr-at-point)))))
@@ -376,7 +376,7 @@ document string."
     (when (and (ts-docstr--line-is "##")
                (ts-docstr--looking-back "##" 2)
                (ts-docstr-activatable-p))
-      (backward-delete-char 2)
+      (delete-char -2)
       (ts-docstr-at-point))))
 
 (defun ts-docstr-key-rust-/ (&rest _)
@@ -385,7 +385,7 @@ document string."
     (when (and (ts-docstr--line-is "///")
                (ts-docstr--looking-back "///" 3)
                (ts-docstr-activatable-p))
-      (backward-delete-char 3)
+      (delete-char -3)
       (ts-docstr-at-point))))
 
 (defun ts-docstr-key-swift-/ (&rest _)
@@ -394,7 +394,7 @@ document string."
     (when (and (ts-docstr--line-is "///")
                (ts-docstr--looking-back "///" 3)
                (ts-docstr-activatable-p))
-      (backward-delete-char 3)
+      (delete-char -3)
       (ts-docstr-at-point))))
 
 (provide 'ts-docstr-key)

--- a/ts-docstr-key.el
+++ b/ts-docstr-key.el
@@ -354,10 +354,15 @@ document string."
     (when (and ts-docstr-mode
                (ts-docstr--string-p)
                (ts-docstr--line-is "\"\"\"\"\"\"")
-               (ts-docstr--looking-back "\"\"\"" 3)
+               (or (ts-docstr--looking-back "\"\"\"" 3)
+                   (ts-docstr--looking-back "\"\"\"\"\"" 5))
                (ts-docstr-activatable-p))
-      (backward-delete-char 3)
-      (delete-char 3)
+      (if (ts-docstr--looking-back "\"\"\"" 5)
+          (progn
+            (backward-delete-char 5)
+            (delete-char 1))
+        (backward-delete-char 3)
+        (delete-char 3))
       (ts-docstr-at-point))))
 
 (defun ts-docstr-key-ruby-sharp (&rest _)

--- a/ts-docstr-key.el
+++ b/ts-docstr-key.el
@@ -357,13 +357,18 @@ document string."
                (or (ts-docstr--looking-back "\"\"\"" 3)
                    (ts-docstr--looking-back "\"\"\"\"\"" 5))
                (ts-docstr-activatable-p))
-      (if (ts-docstr--looking-back "\"\"\"" 5)
-          (progn
-            (backward-delete-char 5)
-            (delete-char 1))
-        (backward-delete-char 3)
-        (delete-char 3))
-      (ts-docstr-at-point))))
+      ;; XXX: Not sure why Python act differently compare to other languages.
+      ;;
+      ;; The current workaround is to keep the old parsed tree.
+      (let ((old-tree tree-sitter-tree))
+        (if (ts-docstr--looking-back "\"\"\"" 5)
+            (progn
+              (backward-delete-char 5)
+              (delete-char 1))
+          (backward-delete-char 3)
+          (delete-char 3))
+        (setq tree-sitter-tree old-tree)  ; keep the old parsed tree
+        (ts-docstr-at-point)))))
 
 (defun ts-docstr-key-ruby-sharp (&rest _)
   "Insert docstring with key."

--- a/ts-docstr.el
+++ b/ts-docstr.el
@@ -396,7 +396,6 @@ Optional argument MODULE is the targeted language's codename."
   "Execute BODY and holds the indent level."
   (declare (indent 0) (debug t))
   `(ts-docstr--setup-insert-env
-     (indent-for-tab-command)
      (let ((ts-docstr-indent-spaces
             (save-excursion
               (buffer-substring (line-beginning-position)


### PR DESCRIPTION
When there is no arguments, we still want to insert the docstring.